### PR TITLE
Change Community Kubecost to Kubecost Team

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@ helm repo add kubecost https://kubecost.github.io/cost-analyzer/
 helm upgrade --install kubecost kubecost/cost-analyzer --namespace kubecost --create-namespace
 ```
 
-This install method provides access to all OpenCost and Community Kubecost functionality, can scale to large clusters, and is available for free.
+This install method provides access to all OpenCost and Kubecost Team functionality, can scale to large clusters, and is available for free.
 
 ## Alternative install options
 


### PR DESCRIPTION
We're trying to phase out alternative names for the Kubecost tiers, like Community Kubecost or Kubecost Free.