### PR TITLE
Updated URLs to reflect move to github.com/opencost 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This website is primarily built using [Docusaurus 2](https://docusaurus.io/), a 
 
 ### Proposing new features and fixes
 
-If you are not (yet!) part of the maintainer team and are considering making changes to the website, please first [create an Issue](https://github.com/kubecost/opencost/issues). That way, we can discuss your changes and ensure they're accepted.
+If you are not (yet!) part of the maintainer team and are considering making changes to the website, please first [create an Issue](https://github.com/opencost/opencost/issues). That way, we can discuss your changes and ensure they're accepted.
 
 ### Implementing changes
 

--- a/blog/2022-06-02-introducing-opencost/index.mdx
+++ b/blog/2022-06-02-introducing-opencost/index.mdx
@@ -32,6 +32,6 @@ Using OpenCost, you can benefit from greater visibility into current and histori
 
 ## Try it yourself!
 
-Check out OpenCost on [GitHub](https://github.com/kubecost/opencost) to get started in less than 3 minutes.
+Check out OpenCost on [GitHub](https://github.com/opencost/opencost) to get started in less than 3 minutes.
 
 Let us know what you think! We love feedback and contributions, and our supportive community is here for any questions in the [#opencost](https://cloud-native.slack.com/archives/C03D56FPD4G) channel on the [CNCF Slack](https://slack.cncf.io/) community.

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -13,5 +13,5 @@ ajay:
 team:
   name: OpenCost Authors
   title: Kubecost Team
-  url: https://github.com/kubecost
+  url: https://github.com/opencost
   image_url: https://user-images.githubusercontent.com/22844059/171157390-cf6c69ee-4c6d-484b-a612-c34e451e50d4.png

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -32,7 +32,7 @@ OpenCost supports a Kubernetes environment above 1.8.
 
 ### How is OpenCost governed?
 
-We are actively forming our governance model. Our plan is to align with the CNCF best practices, found [here](https://www.cncf.io/blog/2019/08/30/cncf-technical-principles-and-open-governance-success/). Today, Kubecost’s technical team contributes all of the code submissions to OpenCost based on the inputs and feedback from a working group of founding contributors. The [OpenCost spec](https://github.com/kubecost/opencost/tree/develop/spec) is co-authored by founding members.
+We are actively forming our governance model. Our plan is to align with the CNCF best practices, found [here](https://www.cncf.io/blog/2019/08/30/cncf-technical-principles-and-open-governance-success/). Today, Kubecost’s technical team contributes all of the code submissions to OpenCost based on the inputs and feedback from a working group of founding contributors. The [OpenCost spec](https://github.com/opencost/opencost/tree/develop/spec) is co-authored by founding members.
 
 ### What does it mean to be a “Founding Contributor”?
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -134,7 +134,7 @@ const config = {
               },
               {
                 label: "GitHub",
-                href: "https://github.com/kubecost/opencost",
+                href: "https://github.com/opencost/opencost",
               },
             ],
           },

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -54,7 +54,7 @@ function Footer() {
             </div>
             <div>
               <a
-                href="https://github.com/kubecost/opencost"
+                href="https://github.com/opencost/opencost"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-white hover:text-green-300 hover:no-underline"
@@ -84,7 +84,7 @@ function Footer() {
         </div>
       </div>
       <div className="text-left md:text-left text-sm px-10">
-        The Linux Foundation® (TLF) has registered trademarks and uses trademarks. 
+        The Linux Foundation® (TLF) has registered trademarks and uses trademarks.
         For a list of TLF trademarks, see:&nbsp;
         <a
           href="https://www.linuxfoundation.org/trademark-usage/"

--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -67,11 +67,11 @@ export default function NavbarContent() {
           )} */}
           <span className="mt-1">
             <GitHubButton
-              href="https://github.com/kubecost/opencost"
+              href="https://github.com/opencost/opencost"
               data-color-scheme="no-preference: light_high_contrast; light: light; dark: light;"
               data-size="large"
               data-show-count="true"
-              aria-label="Star kubecost/opencost on GitHub"
+              aria-label="Star opencost/opencost on GitHub"
             >
               GitHub
             </GitHubButton>


### PR DESCRIPTION
Simple replacement of github.com/kubecost/opencost with github.com/opencost/opencost to reflect new location

Signed-off-by: Matt Ray <github@mattray.dev>