### PR TITLE
Buildchain CVE fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2348,6 +2348,28 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
       "license": "MIT"
@@ -2521,104 +2543,16 @@
       }
     },
     "node_modules/@slorber/static-site-generator-webpack-plugin": {
-      "version": "4.0.4",
-      "license": "MIT",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.7.tgz",
+      "integrity": "sha512-Ug7x6z5lwrz0WqdnNFOMYrDQNTPAprvHLSh6+/fmml3qUiz6l5eq+2MzLKWtn/q5K5NpSiFsZTP/fck/3vjSxA==",
       "dependencies": {
-        "bluebird": "^3.7.1",
-        "cheerio": "^0.22.0",
         "eval": "^0.1.8",
-        "webpack-sources": "^1.4.3"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/cheerio": {
-      "version": "0.22.0",
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
+        "p-map": "^4.0.0",
+        "webpack-sources": "^3.2.2"
       },
       "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/css-select": {
-      "version": "1.2.0",
-      "license": "BSD-like",
-      "dependencies": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/css-what": {
-      "version": "2.1.3",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/dom-serializer": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/domhandler": {
-      "version": "2.4.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/domutils": {
-      "version": "1.5.1",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/entities": {
-      "version": "1.1.2",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin/node_modules/nth-check": {
-      "version": "1.0.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -3642,10 +3576,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.0",
@@ -6997,8 +6927,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "license": "MIT",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -7022,14 +6953,6 @@
       "version": "4.17.21",
       "license": "MIT"
     },
-    "node_modules/lodash.assignin": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.bind": {
-      "version": "4.2.1",
-      "license": "MIT"
-    },
     "node_modules/lodash.curry": {
       "version": "4.1.1",
       "license": "MIT"
@@ -7038,56 +6961,12 @@
       "version": "4.0.8",
       "license": "MIT"
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.filter": {
-      "version": "4.6.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "license": "MIT"
-    },
     "node_modules/lodash.flow": {
       "version": "3.5.0",
       "license": "MIT"
     },
-    "node_modules/lodash.foreach": {
-      "version": "4.5.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.map": {
-      "version": "4.6.0",
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
-      "license": "MIT"
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "license": "MIT"
-    },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.reduce": {
-      "version": "4.6.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.reject": {
-      "version": "4.6.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.some": {
-      "version": "4.6.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -8846,8 +8725,9 @@
       }
     },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "3.2.0",
-      "license": "MIT",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -9096,23 +8976,14 @@
       }
     },
     "node_modules/recursive-readdir": {
-      "version": "2.2.2",
-      "license": "MIT",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "dependencies": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/recursive-readdir/node_modules/minimatch": {
-      "version": "3.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -9750,27 +9621,18 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.3",
-      "license": "MIT",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
+      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
         "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
-        "minimatch": "3.0.4",
+        "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
         "path-to-regexp": "2.2.1",
         "range-parser": "1.2.0"
-      }
-    },
-    "node_modules/serve-handler/node_modules/minimatch": {
-      "version": "3.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {
@@ -9981,10 +9843,6 @@
       "engines": {
         "node": ">= 6.3.0"
       }
-    },
-    "node_modules/source-list-map": {
-      "version": "2.0.1",
-      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -10308,12 +10166,13 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.13.1",
-      "license": "BSD-2-Clause",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -10374,43 +10233,6 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "license": "MIT"
-    },
-    "node_modules/terser/node_modules/punycode": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/terser/node_modules/tr46": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/terser/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/terser/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -11488,11 +11310,11 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/webpack/node_modules/mime-db": {
@@ -11526,13 +11348,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/webpack/node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/webpackbar": {
@@ -13251,6 +13066,27 @@
     "@jridgewell/set-array": {
       "version": "1.1.1"
     },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
+      }
+    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.13"
     },
@@ -13366,90 +13202,13 @@
       "version": "0.14.0"
     },
     "@slorber/static-site-generator-webpack-plugin": {
-      "version": "4.0.4",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.7.tgz",
+      "integrity": "sha512-Ug7x6z5lwrz0WqdnNFOMYrDQNTPAprvHLSh6+/fmml3qUiz6l5eq+2MzLKWtn/q5K5NpSiFsZTP/fck/3vjSxA==",
       "requires": {
-        "bluebird": "^3.7.1",
-        "cheerio": "^0.22.0",
         "eval": "^0.1.8",
-        "webpack-sources": "^1.4.3"
-      },
-      "dependencies": {
-        "cheerio": {
-          "version": "0.22.0",
-          "requires": {
-            "css-select": "~1.2.0",
-            "dom-serializer": "~0.1.0",
-            "entities": "~1.1.1",
-            "htmlparser2": "^3.9.1",
-            "lodash.assignin": "^4.0.9",
-            "lodash.bind": "^4.1.4",
-            "lodash.defaults": "^4.0.1",
-            "lodash.filter": "^4.4.0",
-            "lodash.flatten": "^4.2.0",
-            "lodash.foreach": "^4.3.0",
-            "lodash.map": "^4.4.0",
-            "lodash.merge": "^4.4.0",
-            "lodash.pick": "^4.2.1",
-            "lodash.reduce": "^4.4.0",
-            "lodash.reject": "^4.4.0",
-            "lodash.some": "^4.4.0"
-          }
-        },
-        "css-select": {
-          "version": "1.2.0",
-          "requires": {
-            "boolbase": "~1.0.0",
-            "css-what": "2.1",
-            "domutils": "1.5.1",
-            "nth-check": "~1.0.1"
-          }
-        },
-        "css-what": {
-          "version": "2.1.3"
-        },
-        "dom-serializer": {
-          "version": "0.1.1",
-          "requires": {
-            "domelementtype": "^1.3.0",
-            "entities": "^1.1.1"
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.1"
-        },
-        "domhandler": {
-          "version": "2.4.2",
-          "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "domutils": {
-          "version": "1.5.1",
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "entities": {
-          "version": "1.1.2"
-        },
-        "htmlparser2": {
-          "version": "3.10.1",
-          "requires": {
-            "domelementtype": "^1.3.1",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^3.1.1"
-          }
-        },
-        "nth-check": {
-          "version": "1.0.2",
-          "requires": {
-            "boolbase": "~1.0.0"
-          }
-        }
+        "p-map": "^4.0.0",
+        "webpack-sources": "^3.2.2"
       }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
@@ -14103,9 +13862,6 @@
     },
     "binary-extensions": {
       "version": "2.2.0"
-    },
-    "bluebird": {
-      "version": "3.7.2"
     },
     "body-parser": {
       "version": "1.20.0",
@@ -16058,7 +15814,9 @@
       "version": "4.3.0"
     },
     "loader-utils": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -16074,56 +15832,17 @@
     "lodash": {
       "version": "4.17.21"
     },
-    "lodash.assignin": {
-      "version": "4.2.0"
-    },
-    "lodash.bind": {
-      "version": "4.2.1"
-    },
     "lodash.curry": {
       "version": "4.1.1"
     },
     "lodash.debounce": {
       "version": "4.0.8"
     },
-    "lodash.defaults": {
-      "version": "4.2.0"
-    },
-    "lodash.filter": {
-      "version": "4.6.0"
-    },
-    "lodash.flatten": {
-      "version": "4.4.0"
-    },
     "lodash.flow": {
       "version": "3.5.0"
     },
-    "lodash.foreach": {
-      "version": "4.5.0"
-    },
-    "lodash.map": {
-      "version": "4.6.0"
-    },
     "lodash.memoize": {
       "version": "4.1.2"
-    },
-    "lodash.merge": {
-      "version": "4.6.2"
-    },
-    "lodash.pick": {
-      "version": "4.4.0"
-    },
-    "lodash.reduce": {
-      "version": "4.6.0"
-    },
-    "lodash.reject": {
-      "version": "4.6.0"
-    },
-    "lodash.some": {
-      "version": "4.6.0"
-    },
-    "lodash.sortby": {
-      "version": "4.7.0"
     },
     "lodash.uniq": {
       "version": "4.5.0"
@@ -17074,7 +16793,9 @@
           "version": "4.0.0"
         },
         "loader-utils": {
-          "version": "3.2.0"
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+          "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw=="
         },
         "locate-path": {
           "version": "6.0.0",
@@ -17231,17 +16952,11 @@
       }
     },
     "recursive-readdir": {
-      "version": "2.2.2",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "requires": {
-        "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
+        "minimatch": "^3.0.5"
       }
     },
     "regenerate": {
@@ -17657,24 +17372,20 @@
       }
     },
     "serve-handler": {
-      "version": "6.1.3",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
+      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
       "requires": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
         "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
-        "minimatch": "3.0.4",
+        "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
         "path-to-regexp": "2.2.1",
         "range-parser": "1.2.0"
       },
       "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
         "path-to-regexp": {
           "version": "2.2.1"
         }
@@ -17812,9 +17523,6 @@
     },
     "sort-css-media-queries": {
       "version": "2.0.4"
-    },
-    "source-list-map": {
-      "version": "2.0.1"
     },
     "source-map": {
       "version": "0.6.1"
@@ -18004,42 +17712,18 @@
       "version": "2.2.1"
     },
     "terser": {
-      "version": "5.13.1",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
         "commander": {
           "version": "2.20.3"
-        },
-        "punycode": {
-          "version": "2.1.1"
-        },
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2"
-        },
-        "whatwg-url": {
-          "version": "7.1.0",
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
         }
       }
     },
@@ -18501,9 +18185,6 @@
             "ajv": "^6.12.5",
             "ajv-keywords": "^3.5.2"
           }
-        },
-        "webpack-sources": {
-          "version": "3.2.3"
         }
       }
     },
@@ -18682,11 +18363,9 @@
       }
     },
     "webpack-sources": {
-      "version": "1.4.3",
-      "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      }
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
     },
     "webpackbar": {
       "version": "5.0.2",


### PR DESCRIPTION
Ran npm audit fix to patch a critical CVE in buildchain.

Updates all references to `loader-utils` to > 2.0.4